### PR TITLE
Add keymaps to repeat last command and last jump command

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Note that multiple windows can be opened at the same time.
 - <kbd>gn</kbd> (Switch to previous group)
 - <kbd>gs\<1-9></kbd> (Swap current group with group \<1-9> and switch to it)
 - <kbd>go\<1-9></kbd> (Overwrite group \<1-9> with the current group and switch to it)
+- <kbd>.</kbd> (Repeat last command (zoom, scroll, search or switch to previous mark or group))
+- <kbd>,</kbd> (Repeat last jump command (switch to previous mark or group))
 - <kbd>/</kbd>, <kbd>Esc</kbd> (Show/hide search dialog)
 - <kbd>o</kbd> (Open file chooser)
 - <kbd>Tab</kbd> (Toggle table of contents)

--- a/data/app.1.in
+++ b/data/app.1.in
@@ -100,6 +100,12 @@ Swap current group with group <1-9> and switch to it.
 .B go<1-9>
 Overwrite group <1-9> with the current cursor and switch to it.
 .TP
+.B .
+Repeat last command (zoom, scroll, search or switch to previous mark or group)
+.TP
+.B ,
+Repeat last jump command (switch to previous mark or group)
+.TP
 .B /
 Show/hide search dialog.
 .TP

--- a/src/input_FSM.c
+++ b/src/input_FSM.c
@@ -110,14 +110,10 @@ InputState on_state_g(Window *window, guint keyval)
         command = command_new((CommandExecute)switch_to_previous_group, 1, mark_manager);
         command_execute(command, viewer);
 
-        if (viewer->last_command == viewer->last_jump_command) {
-            free(viewer->last_command);
-        } else {
-            free(viewer->last_command);
-            free(viewer->last_jump_command);
-        }
+        free(viewer->last_command);
+        free(viewer->last_jump_command);
         viewer->last_command = command;
-        viewer->last_jump_command = command;
+        viewer->last_jump_command = command_copy(command);
     } else if (keyval == GDK_KEY_s) {
         next_state = STATE_GROUP_SWAP;
     } else if (keyval == GDK_KEY_o) {
@@ -271,14 +267,10 @@ InputState on_state_mark(Window *window, guint keyval)
         command = command_new((CommandExecute)switch_to_previous_mark, 1, mark_manager);
         command_execute(command, viewer);
 
-        if (viewer->last_command == viewer->last_jump_command) {
-            free(viewer->last_command);
-        } else {
-            free(viewer->last_command);
-            free(viewer->last_jump_command);
-        }
+        free(viewer->last_command);
+        free(viewer->last_jump_command);
         viewer->last_command = command;
-        viewer->last_jump_command = command;
+        viewer->last_jump_command = command_copy(command);
     } else if (keyval == GDK_KEY_c) {
         next_state = STATE_MARK_CLEAR;
     } else if (keyval == GDK_KEY_s) {

--- a/src/input_FSM.h
+++ b/src/input_FSM.h
@@ -17,8 +17,6 @@ typedef enum {
     STATE_MARK_OVERWRITE,
 } InputState;
 
-typedef InputState(*input_state_func)(Window *, guint);
-
 InputState on_state_normal(Window *window, guint keyval);
 InputState on_state_g(Window *window, guint keyval);
 InputState on_state_number(Window *window, guint keyval);

--- a/src/input_cmd.c
+++ b/src/input_cmd.c
@@ -6,12 +6,24 @@
 Command *command_new(CommandExecute execute, unsigned int repeat_count, void *data)
 {
     Command *command = malloc(sizeof(Command));
+    if (command == NULL) {
+        return NULL;
+    }
 
     command->execute = execute;
     command->repeat_count = repeat_count;
     command->data = data;
 
     return command;
+}
+
+Command *command_copy(Command *command)
+{
+    if (command == NULL) {
+        return NULL;
+    }
+
+    return command_new(command->execute, command->repeat_count, command->data);
 }
 
 void command_execute(Command *command, Viewer *viewer)

--- a/src/input_cmd.c
+++ b/src/input_cmd.c
@@ -1,0 +1,162 @@
+#include "input_cmd.h"
+#include "viewer.h"
+#include "viewer_mark_manager.h"
+#include "utils.h"
+
+Command *command_new(CommandExecute execute, unsigned int repeat_count, void *data)
+{
+    Command *command = malloc(sizeof(Command));
+
+    command->execute = execute;
+    command->repeat_count = repeat_count;
+    command->data = data;
+
+    return command;
+}
+
+void command_execute(Command *command, Viewer *viewer)
+{
+    if (command != NULL && command->execute != NULL) {
+        command->execute(viewer, command->repeat_count, command->data);
+    }
+}
+
+void zoom_in(struct Viewer *viewer, unsigned int repeat_count, void *data)
+{
+    double scale_step = *(double *)data;
+
+    for (unsigned int i = 0; i < repeat_count; i++) {
+        viewer_cursor_set_scale(viewer->cursor, viewer->cursor->scale + scale_step);
+    }
+}
+
+void zoom_out(struct Viewer *viewer, unsigned int repeat_count, void *data)
+{
+    double scale_step = *(double *)data;
+
+    for (unsigned int i = 0; i < repeat_count; i++) {
+        viewer_cursor_set_scale(viewer->cursor, viewer->cursor->scale - scale_step);
+    }
+}
+
+void scroll_half_page_up(struct Viewer *viewer, unsigned int repeat_count, void *data)
+{
+    int step = *(int *)data;
+
+    for (unsigned int i = 0; i < repeat_count; i++) {
+        viewer->cursor->y_offset -= step / 2;
+    }
+}
+
+void scroll_half_page_down(struct Viewer *viewer, unsigned int repeat_count, void *data)
+{
+    int step = *(int *)data;
+
+    for (unsigned int i = 0; i < repeat_count; i++) {
+        viewer->cursor->y_offset += step / 2;
+    }
+}
+
+void scroll_left(struct Viewer *viewer, unsigned int repeat_count, void *data)
+{
+    UNUSED(data);
+
+    for (unsigned int i = 0; i < repeat_count; i++) {
+        viewer->cursor->x_offset--;
+    }
+}
+
+void scroll_down(struct Viewer *viewer, unsigned int repeat_count, void *data)
+{
+    UNUSED(data);
+
+    for (unsigned int i = 0; i < repeat_count; i++) {
+        viewer->cursor->y_offset++;
+    }
+}
+
+void scroll_up(struct Viewer *viewer, unsigned int repeat_count, void *data)
+{
+    UNUSED(data);
+
+    for (unsigned int i = 0; i < repeat_count; i++) {
+        viewer->cursor->y_offset--;
+    }
+}
+
+void scroll_right(struct Viewer *viewer, unsigned int repeat_count, void *data)
+{
+    UNUSED(data);
+
+    for (unsigned int i = 0; i < repeat_count; i++) {
+        viewer->cursor->x_offset++;
+    }
+}
+
+void forward_search(struct Viewer *viewer, unsigned int repeat_count, void *data)
+{
+    ViewerMarkManager *mark_manager = (ViewerMarkManager *)data;
+
+    ViewerCursor *current_cursor = viewer_mark_manager_get_current_cursor(mark_manager);
+    ViewerCursor *search_new_cursor = current_cursor;
+    ViewerCursor *last_search_cursor = NULL;
+    ViewerCursor *resulting_cursor = NULL;
+
+    for (unsigned int i = 0; i < repeat_count; i++) {
+        last_search_cursor = search_new_cursor;
+        search_new_cursor = viewer_search_get_next_search(viewer->search, search_new_cursor);
+        if (search_new_cursor == NULL) {
+            resulting_cursor = last_search_cursor;
+            break;
+        }
+
+        viewer_cursor_destroy(last_search_cursor);
+        free(last_search_cursor);
+        resulting_cursor = search_new_cursor;
+    }
+
+    viewer_mark_manager_set_current_cursor(mark_manager, resulting_cursor);
+}
+
+void backward_search(struct Viewer *viewer, unsigned int repeat_count, void *data)
+{
+    ViewerMarkManager *mark_manager = (ViewerMarkManager *)data;
+
+    ViewerCursor *current_cursor = viewer_mark_manager_get_current_cursor(mark_manager);
+    ViewerCursor *search_new_cursor = current_cursor;
+    ViewerCursor *last_search_cursor = NULL;
+    ViewerCursor *resulting_cursor = NULL;
+
+    for (unsigned int i = 0; i < repeat_count; i++) {
+        last_search_cursor = search_new_cursor;
+        search_new_cursor = viewer_search_get_prev_search(viewer->search, search_new_cursor);
+        if (search_new_cursor == NULL) {
+            resulting_cursor = last_search_cursor;
+            break;
+        }
+
+        viewer_cursor_destroy(last_search_cursor);
+        free(last_search_cursor);
+        resulting_cursor = search_new_cursor;
+    }
+
+    viewer_mark_manager_set_current_cursor(mark_manager, resulting_cursor);
+}
+
+void switch_to_previous_mark(struct Viewer *viewer, unsigned int repeat_count, void *data)
+{
+    UNUSED(viewer);
+    UNUSED(repeat_count);
+
+    ViewerMarkManager *mark_manager = (ViewerMarkManager *)data;
+    viewer_mark_manager_switch_to_previous_mark(mark_manager);
+}
+
+void switch_to_previous_group(struct Viewer *viewer, unsigned int repeat_count, void *data)
+{
+    UNUSED(viewer);
+    UNUSED(repeat_count);
+
+    ViewerMarkManager *mark_manager = (ViewerMarkManager *)data;
+    viewer_mark_manager_switch_to_previous_group(mark_manager);
+}

--- a/src/input_cmd.h
+++ b/src/input_cmd.h
@@ -1,0 +1,27 @@
+#pragma once
+
+struct Viewer;
+
+typedef void (*CommandExecute)(struct Viewer *viewer, unsigned int repeat_count, void *data);
+
+typedef struct {
+    CommandExecute execute;
+    unsigned int repeat_count;
+    void *data;
+} Command;
+
+Command *command_new(CommandExecute execute, unsigned int repeat_count, void *data);
+void command_execute(Command *command, struct Viewer *viewer);
+
+void zoom_in(struct Viewer *viewer, unsigned int repeat_count, void *data);
+void zoom_out(struct Viewer *viewer, unsigned int repeat_count, void *data);
+void scroll_half_page_up(struct Viewer *viewer, unsigned int repeat_count, void *data);
+void scroll_half_page_down(struct Viewer *viewer, unsigned int repeat_count, void *data);
+void scroll_left(struct Viewer *viewer, unsigned int repeat_count, void *data);
+void scroll_down(struct Viewer *viewer, unsigned int repeat_count, void *data);
+void scroll_up(struct Viewer *viewer, unsigned int repeat_count, void *data);
+void scroll_right(struct Viewer *viewer, unsigned int repeat_count, void *data);
+void forward_search(struct Viewer *viewer, unsigned int repeat_count, void *data);
+void backward_search(struct Viewer *viewer, unsigned int repeat_count, void *data);
+void switch_to_previous_mark(struct Viewer *viewer, unsigned int repeat_count, void *data);
+void switch_to_previous_group(struct Viewer *viewer, unsigned int repeat_count, void *data);

--- a/src/input_cmd.h
+++ b/src/input_cmd.h
@@ -11,6 +11,7 @@ typedef struct {
 } Command;
 
 Command *command_new(CommandExecute execute, unsigned int repeat_count, void *data);
+Command *command_copy(Command *command);
 void command_execute(Command *command, struct Viewer *viewer);
 
 void zoom_in(struct Viewer *viewer, unsigned int repeat_count, void *data);

--- a/src/meson.build
+++ b/src/meson.build
@@ -9,6 +9,7 @@ sources = [
     'database.c',
     'viewer.c',
     'renderer.c',
+    'input_cmd.c',
     'input_FSM.c',
     'page.c',
     'viewer_info.c',

--- a/src/viewer.c
+++ b/src/viewer.c
@@ -45,12 +45,8 @@ void viewer_destroy(Viewer *viewer)
     viewer_info_destroy(viewer->info);
     free(viewer->info);
 
-    if (viewer->last_command == viewer->last_jump_command) {
-        free(viewer->last_command);
-    } else {
-        free(viewer->last_command);
-        free(viewer->last_jump_command);
-    }
+    free(viewer->last_command);
+    free(viewer->last_jump_command);
 }
 
 void viewer_update_current_page_size(Viewer *viewer)

--- a/src/viewer.c
+++ b/src/viewer.c
@@ -26,6 +26,8 @@ void viewer_init(Viewer *viewer, ViewerInfo *info, ViewerCursor *cursor, ViewerS
     viewer->cursor = cursor;
     viewer->search = search;
     viewer->links = links;
+    viewer->last_command = NULL;
+    viewer->last_jump_command = NULL;
 }
 
 void viewer_destroy(Viewer *viewer)
@@ -42,6 +44,13 @@ void viewer_destroy(Viewer *viewer)
 
     viewer_info_destroy(viewer->info);
     free(viewer->info);
+
+    if (viewer->last_command == viewer->last_jump_command) {
+        free(viewer->last_command);
+    } else {
+        free(viewer->last_command);
+        free(viewer->last_jump_command);
+    }
 }
 
 void viewer_update_current_page_size(Viewer *viewer)

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -4,12 +4,15 @@
 #include "viewer_cursor.h"
 #include "viewer_search.h"
 #include "viewer_links.h"
+#include "input_cmd.h"
 
 typedef struct Viewer {
     ViewerInfo *info;
     ViewerCursor *cursor;
     ViewerSearch *search;
     ViewerLinks *links;
+    Command *last_command;
+    Command *last_jump_command;
 } Viewer;
 
 Viewer *viewer_new(ViewerInfo *info, ViewerCursor *cursor, ViewerSearch *search, ViewerLinks *links);

--- a/src/viewer_info.c
+++ b/src/viewer_info.c
@@ -92,7 +92,7 @@ PopplerDest *viewer_info_get_dest(ViewerInfo *info, PopplerDest *dest)
 
 PopplerPage *viewer_info_get_poppler_page(ViewerInfo *info, int page_num)
 {
-    if (page_num >= info->n_pages) {
+    if (page_num < 0 || page_num >= info->n_pages) {
         return NULL;
     }
 

--- a/src/window.c
+++ b/src/window.c
@@ -50,6 +50,8 @@ static const Keybinding keybindings[] = {
     {"gn", "Switch to previous group", 0},
     {"gs<1-9>", "Swap current group with group <1-9> and switch to it", 0},
     {"go<1-9>", "Overwrite group <1-9> with the current group and switch to it", 0},
+    {".", "Repeat last command (zoom, scroll, search or switch to previous mark or group)", 0},
+    {",", "Repeat last jump command (switch to previous mark or group)", 0},
     {"/, Esc", "Show/hide search dialog", 0},
     {"o", "Open file chooser", 0},
     {"Tab", "Toggle table of contents", 0},

--- a/src/window.c
+++ b/src/window.c
@@ -258,6 +258,9 @@ static void window_finalize(GObject *object)
         viewer_links_destroy(win->viewer->links);
         free(win->viewer->links);
 
+        free(win->viewer->last_command);
+        free(win->viewer->last_jump_command);
+
         free(win->viewer);
     }
 


### PR DESCRIPTION
Make <kbd>.</kbd> repeat the last command and <kbd>,</kbd> the last jump command. The main reason is that <kbd>mn</kbd> or <kbd>gn</kbd> requires 2 keystrokes, which is inefficient since the jump commands are usually used to repeatedly switch back and forth between 2 locations. The reason behind the last jump command being separate from the last command is that after jumping, one usually scrolls around a bit before jumping back, but then the last command is no longer a jump back.