### PR TITLE
Make drawing more responsive

### DIFF
--- a/src/page.c
+++ b/src/page.c
@@ -11,6 +11,7 @@ Page *page_new(PopplerPage *poppler_page)
     page->render_status = PAGE_NOT_RENDERED;
     page->surface = NULL;
     g_mutex_init(&page->render_mutex);
+    page->reset_pending = 0;
 
     return page;
 }
@@ -30,4 +31,16 @@ void page_destroy(Page *page)
     }
 
     g_mutex_clear(&page->render_mutex);
+
+    page->reset_pending = 0;
+}
+
+void page_reset_render(Page *page)
+{
+    if (page->surface != NULL) {
+        cairo_surface_destroy(page->surface);
+        page->surface = NULL;
+    }
+
+    page->render_status = PAGE_NOT_RENDERED;
 }

--- a/src/page.h
+++ b/src/page.h
@@ -2,6 +2,7 @@
 
 #include <poppler.h>
 #include <cairo.h>
+#include <glib.h>
 #include <stdbool.h>
 
 typedef enum {
@@ -15,7 +16,10 @@ typedef struct {
     PageRenderStatus render_status;
     cairo_surface_t *surface;
     GMutex render_mutex;
+    gint reset_pending;
 } Page;
 
 Page *page_new(PopplerPage *poppler_page);
 void page_destroy(Page *page);
+
+void page_reset_render(Page *page);

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -269,10 +269,6 @@ static void renderer_queue_page_render(Renderer *renderer, Viewer *viewer, Page*
             g_warning("Failed to push render task to thread pool: %s", error->message);
             g_error_free(error);
             g_free(data);
-        } else {
-            g_mutex_lock(&page->render_mutex);
-            page->render_status = PAGE_RENDERING;
-            g_mutex_unlock(&page->render_mutex);
         }
     } else {
         g_mutex_unlock(&page->render_mutex);
@@ -303,6 +299,7 @@ static void render_page_async(gpointer data, gpointer user_data)
 
     g_mutex_lock(&page->render_mutex);
 
+    page->render_status = PAGE_RENDERING;
     renderer_render_page(renderer, viewer, cr, page->poppler_page, draw_links_from, draw_links_to);
 
     if (page->surface != NULL) {


### PR DESCRIPTION
While rendering a page, the page mutex is locked. Thus, when trying to draw the page while it is still rendering, it blocks. This PR instead draws a loading page when still rendering. In addition, when trying to reset a page still rendering, we now schedule it for reset after it has been rendered.